### PR TITLE
Add VOut to default output

### DIFF
--- a/src/include/algorithm.c
+++ b/src/include/algorithm.c
@@ -29,7 +29,7 @@
 #include "cliargs.h"
 #include "read_file.h"
 
-float answer[3][5];
+float answer[4][5];
 unsigned short answer_pos = 0;
 
 void algorithm(void){
@@ -51,6 +51,7 @@ void algorithm(void){
                 answer[0][0] = (float)resistors[i];
                 answer[1][0] = (float)resistors[j];
                 answer[2][0] = current_error;
+                answer[3][0] = vout_parcial;
             } else {
                 // Save how full the array is
                 unsigned int answer_max = answer_pos;
@@ -63,11 +64,13 @@ void algorithm(void){
                         answer[0][answer_pos+1] = answer[0][answer_pos];
                         answer[1][answer_pos+1] = answer[1][answer_pos];
                         answer[2][answer_pos+1] = answer[2][answer_pos];
+                        answer[3][answer_pos+1] = answer[3][answer_pos];
 
                         // The new element gets introduced in the array
                         answer[0][answer_pos] = (float)resistors[i];
                         answer[1][answer_pos] = (float)resistors[j];
                         answer[2][answer_pos] = current_error;
+                        answer[3][answer_pos] = vout_parcial;
 
                         // If we added a new element in the array
                         if(answer_max == answer_pos){
@@ -87,6 +90,7 @@ void algorithm(void){
                         answer[0][answer_pos] = (float)resistors[i];
                         answer[1][answer_pos] = (float)resistors[j];
                         answer[2][answer_pos] = current_error;
+                        answer[3][answer_pos] = vout_parcial;
                        
                         answer_pos--;
                     }
@@ -106,6 +110,7 @@ void print_answer(void){
     for(unsigned short i = 0; i < 5; i++){
         printf("R1: %.0f  \t", answer[0][i]);
         printf("R2: %.0f  \t", answer[1][i]);
-        printf("Error: %.4f%\n", answer[2][i]);
+        printf("Error: %.4f%  \t", answer[2][i]);
+        printf("VOut: %.2fV\n", answer[3][i]);
     }
 }

--- a/src/include/algorithm.h
+++ b/src/include/algorithm.h
@@ -22,7 +22,7 @@
 */
 
 
-extern float answer[3][5];
+extern float answer[4][5];
 
 void algorithm(void);
 float vout_function(float, float, float);


### PR DESCRIPTION
As I usually calculate a target voltage, seeing the actual calculated output is more useful than just a error percentage. Currently VOut is only shown in verbose calculations. This PR adds it to the default output.

```
$ ./vdf 12 4.7 resistor 
Vin: 12.00
Vout: 4.70
R1: 5100  	R2: 3300  	Error: 0.3040% 	VOut: 4.71V
R1: 510  	R2: 330  	Error: 0.3040% 	VOut: 4.71V
R1: 3300  	R2: 2200  	Error: 2.1277% 	VOut: 4.80V
R1: 330  	R2: 220  	Error: 2.1277% 	VOut: 4.80V
R1: 150  	R2: 100  	Error: 2.1277% 	VOut: 4.80V
```